### PR TITLE
feat(agy): Add option to disable auto-update in Antigravity CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,42 @@ Headers: {"Alt-Svc":["h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"],"Cont
 }
 ```
 
+## 💡 Antigravity CLI и авто-обновления
+Последняя рабочая версия Antigravity CLI — **[v1.1.7](https://github.com/google-antigravity/antigravity-cli/releases/tag/1.1.7)**.
+Замените им ваш текущий установленный бинарник `agy` / `agy.exe` если версия вашего CLI выше.
+
+В экосистеме Antigravity авто-обновление работает на двух уровнях:
+1. **Внутренний модуль `bg-updater` самого `agy.exe`** — отключается патчем **PATCH ➔ `4`** в патчере.
+2. **Внешний сервис Antigravity 2.0 (`language_server.exe`)** — при запуске проверяет сервера Google и **принудительно перезаписывает `agy.exe`** свежей версией поверх вашего файла.
+
+### 🛡️ Блокировка авто-обновления
+
+ Чтобы полностью заблокировать перезапись бинарника:
+
+1. **Защитите файл `agy` от перезаписи фоновым сервисом (Read-Only)**:
+   После применения патча установите для `agy.exe` атрибут «Только чтение». Фоновый сервис `language_server` не сможет перезаписать ваш файл.
+   * **Windows (CMD / PowerShell)**:
+     ```cmd
+     attrib +r "C:\Users\%USERNAME%\AppData\Local\agy\bin\agy.exe"
+     ```
+     *(Или в Свойствах файла `agy.exe` поставьте галочку **«Только чтение»**).*
+   * **Linux / macOS**:
+     ```bash
+     chmod 555 ~/.local/bin/agy
+     ```
+
+2. **Встроенный байт-патч (PATCH ➔ `4`: Disable Auto-Update)**:
+   Отключает модуль `bg-updater` внутри самого бинарника `agy`/`agy.exe` (`c6 42 50 00`).
+
+3. **Переменная окружения `AGY_CLI_DISABLE_AUTO_UPDATE` (Не проверено в долгосрочной перспективе)**:
+   Точное имя переменной, зашитое в Go-коде `agy`:
+   * **Windows (CMD)**: `setx AGY_CLI_DISABLE_AUTO_UPDATE true`
+   * **Windows (PowerShell)**: `[System.Environment]::SetEnvironmentVariable("AGY_CLI_DISABLE_AUTO_UPDATE", "true", "User")`
+   * **Linux / macOS**: добавьте `export AGY_CLI_DISABLE_AUTO_UPDATE=true` в `~/.bashrc` / `~/.zshrc`.
+
+4. **Флаг запуска CLI (Не проверено в долгосрочной перспективе)**:
+   `agy --bg-updater=false`
+
 ## ⚠️ Ошибка лицензии Antigravity CLI (#3501)
 Если в Antigravity CLI (`agy`) появляется ошибка `You do not have a valid license of this product`, это не проблема локального патча и не экран `Eligibility Check`.
 
@@ -108,8 +144,9 @@ Trajectory ID: d3ee4302-4213-40f9-9ac5-42e83e38a5ce
 
 ## 🌟 Возможности
 - Автоматический поиск установленного Antigravity 2.0, Antigravity IDE и Antigravity CLI (`agy`) в стандартных путях и реестре Windows.
-- **Проверка обновлений** — автоматическая проверка новых версий при запуске и ручная проверка через меню (TOOLS → `7`).
+- **Проверка обновлений** — автоматическая проверка новых версий при запуске и ручная проверка через меню (TOOLS → `8`).
 - **Патч Antigravity CLI** — снятие экрана «Eligibility Check» в Go-бинаре `agy`/`agy.exe` на уровне машинного кода по байтовой сигнатуре для архитектур x86-64 и ARM64 (с резервной копией и откатом).
+- **Отключение авто-обновлений CLI (Disable Auto-Update)** — байт-патчинг `bg-updater` в `agy`/`agy.exe` для отключения проверки и загрузки обновлений.
 - **Патч Antigravity Manager (`language_server`)** — снятие проверки авторизации (`hasValidAuth=true`) в скомпилированном бинарнике бэкенда по байтовой сигнатуре для архитектур x86-64 и ARM64 (с резервной копией и откатом).
 - Поддержка Linux: поиск по `/usr/share/antigravity-ide`, определение версии через `dpkg`, `rpm` и `package.json`.
 - Поддержка macOS: поиск `.app`-бандла в `/Applications` и `~/Applications`, ad-hoc переподпись после изменения `main.js`.
@@ -132,14 +169,15 @@ Trajectory ID: d3ee4302-4213-40f9-9ac5-42e83e38a5ce
 | `1` Antigravity IDE patch | Применить патч к `main.js` для Antigravity IDE (bypass region lock) |
 | `2` Antigravity 2.0 patch | Применить патч к бинарному файлу `language_server` (Antigravity Manager) |
 | `3` Antigravity CLI (agy) patch | Применить патч к бинарю `agy`/`agy.exe` (unlock agy tool) |
+| `4` Disable Auto-Update (agy) | Отключить авто-обновление `bg-updater` в `agy`/`agy.exe` |
 | **RESTORE** | |
-| `4` Antigravity IDE | Восстановить оригинальный `main.js` для Antigravity IDE из бэкапа |
-| `5` Antigravity 2.0 | Восстановить оригинальный `language_server` из бэкапа |
-| `6` Antigravity CLI | Восстановить оригинальный `agy`/`agy.exe` из бэкапа |
+| `5` Antigravity IDE | Восстановить оригинальный `main.js` для Antigravity IDE из бэкапа |
+| `6` Antigravity 2.0 | Восстановить оригинальный `language_server` из бэкапа |
+| `7` Antigravity CLI | Восстановить оригинальный `agy`/`agy.exe` из бэкапа |
 | **TOOLS** | |
-| `7` Check for updates | Проверить наличие новых версий на GitHub |
-| `8` Open GitHub repository | Открыть страницу проекта в браузере |
-| `9` Select custom path | Выбрать путь к папке приложения или файлу вручную |
+| `8` Check for updates | Проверить наличие новых версий на GitHub |
+| `9` Open GitHub repository | Открыть страницу проекта в браузере |
+| `10` Select custom path | Выбрать путь к папке приложения или файлу вручную |
 | **`0` Exit** | Выйти из патчера |
 
 Запуск из исходников:
@@ -210,13 +248,14 @@ xattr -dr com.apple.quarantine Open_AG_Patcher_macOS
 - **PATCH → `1`** (Antigravity IDE patch) для `Antigravity IDE.app`
 - **PATCH → `2`** (Antigravity 2.0 patch) для `Antigravity.app` (бэкенд language_server)
 - **PATCH → `3`** (Antigravity CLI (agy) patch) для бинаря `agy` (если установлен)
-- **RESTORE → `4`**, `5` или `6` для восстановления из бэкапа
+- **PATCH → `4`** (Disable Auto-Update (agy)) для отключения авто-обновления `agy`
+- **RESTORE → `5`**, `6` или `7` для восстановления из бэкапа
 
 Для `Antigravity.app` патчер обычно сам находит:
 ```text
 /Applications/Antigravity.app
 ```
-Если автопоиск не нашел приложение, выберите **TOOLS → `9`** (Select custom path) и укажите один из путей:
+Если автопоиск не нашел приложение, выберите **TOOLS → `10`** (Select custom path) и укажите один из путей:
 ```text
 /Applications/Antigravity.app
 /Applications/Antigravity IDE.app
@@ -251,7 +290,7 @@ Antigravity Manager (`language_server` или `language_server.exe`) — бэк�
 - **ARM64** (Linux arm64 / Apple Silicon macOS): Находит и заменяет последовательность `ldrb w3, [x0, #8] ; tbz w3, #0, skip` на `mov w3, #1 ; strb w3, [x0, #8]` (`\x23\x00\x80\x52\x03\x20\x00\x39`).
 
 В результате возвращаемое значение `hasValidAuth` всегда принудительно выставляется в `true`, снимая блокировку.
-Патч обратим через **RESTORE → `5`** восстановлением оригинального бинарника из `.agybak`.
+Патч обратим через **RESTORE → `6`** восстановлением оригинального бинарника из `.agybak`.
 
 ### Патч для Antigravity CLI (agy)
 
@@ -282,11 +321,23 @@ Antigravity CLI — отдельный Go-бинарь (`agy.exe` на Windows, 
 **Безопасность патча:**
 - Если байтовая сигнатура не найдена в бинаре (неизвестная/неподдерживаемая версия), патчер **отказывается патчить** и ничего не меняет — выводится «signature not found (unsupported version?)».
 - Если сигнатура встречается больше одного раза, патчер тоже отказывается («not unique — refusing to guess») — не угадывает, какой сайт править.
-- Откат выполняется через **RESTORE → `6`** (Antigravity CLI) восстановлением из `.agybak`.
+- Откат выполняется через **RESTORE → `7`** (Antigravity CLI) восстановлением из `.agybak`.
 
 > **Примечание по платформам:** сигнатура для x86-64 проверена под Windows и Intel macOS, для ARM64 — под Apple Silicon macOS. Discovery ищет бинарь кроссплатформенно (`PATH`, scoop на Windows, `/usr/local/bin`, `/opt/antigravity/bin`, `~/.local/bin` на POSIX). На Linux бинарь `agy` может быть скомпилирован иначе, и сигнатура может не совпасть — в этом случае патч честно сообщит об этом без модификации файла.
 
 > **Примечание:** проверка «Eligibility check failed: Your current account is not eligible for Antigravity, because it is not currently available in your location» выполняется на стороне сервера. Патч снимает только локальный косметический экран «⚠ Eligibility Check» в `handleAuthResult`, но не может обойти серверную проверку доступности региона.
+
+### Патч отключения авто-обновления Antigravity CLI (Disable Auto-Update)
+
+В бинарнике Antigravity CLI авто-обновление нейтрализуется двухуровневым машинным байт-патчем через опцию **PATCH ➔ `4` (Disable Auto-Update (agy))**:
+1. **Флаг фоновой проверки `bg-updater`**:
+   * Находит инструкцию включения флага `mov byte ptr [rdx+0x50], 1` (`\xc6\x42\x50\x01`).
+   * Заменяет значение байта на `0x00` (`\xc6\x42\x50\x00`), полностью отключая ветку фонового таймера проверки.
+2. **Ядро функции обновления (`sub_14273BE40`)**:
+   * Находит точку входа основной скомпилированной функции проверки, загрузки и установки релизов с серверов Google (по сигнатуре инструкции `Checking for updates...`).
+   * Патчит точку входа на команды мгновенного возврата `xor rax, rax; xor rbx, rbx; ret; nop` (`\x48\x31\xc0\x48\x31\xdb\xc3\x90`).
+   * В результате при ЛЮБОМ вызове (ручном `agy update` или вызове из IDE) функция обновления мгновенно возвращает результат `nil` без вызова сетевых функций и скачиваний.
+
 
 ## 🔍 Логика поиска файла
 
@@ -318,7 +369,7 @@ Antigravity CLI — отдельный Go-бинарь (`agy.exe` на Windows, 
 
 Бинарь `agy` (`agy.exe` на Windows) ищется location-agnostic — по `PATH` и стандартным каталогам, без хардкодных путей/версий:
 
-1. Аргумент командной строки или **TOOLS → `9` → `3`** (путь к файлу `agy`/`agy.exe` или к папке).
+1. Аргумент командной строки или **TOOLS → `10` → `3`** (путь к файлу `agy`/`agy.exe` или к папке).
 2. `PATH` (`shutil.which("agy")`).
 3. Стандартные каталоги:
    - **Windows:** `%LOCALAPPDATA%`, `%PROGRAMFILES%`, `%PROGRAMFILES(X86)%`, `%ProgramData%`, `%APPDATA%` (+ подпапки `Programs`), scoop (`%USERPROFILE%\scoop\apps`, `%SCOOP%\apps`). Шаблоны: `agy/bin/agy.exe`, `agy/*/bin/agy.exe` (scoop version-dirs), `agy*/agy.exe`.

--- a/source/patcher/agy/patcher.py
+++ b/source/patcher/agy/patcher.py
@@ -109,6 +109,33 @@ CLI_GATE = MultiGate(
     desc="eligibility screen off",
 )
 
+# ---------------------------------------------------------------------------
+# Gate 2 (bg-updater & updater core): disable automatic background update checking/installing.
+# amd64: mov rdx,[rax]; mov byte ptr [rdx+0x50], 1 -> patch 1 -> 0
+CLI_AUTOUPDATE_BG_X64 = Gate(
+    rb"\x48\x8d\x0d[\s\S]{4}\xbf\x0a\x00\x00\x00[\s\S]{5}\x48\x8b\x10\xc6\x42\x50\x01\x90[\s\S]{50,70}\x48\x8d\x0d[\s\S]{4}\xbf\x0a\x00\x00\x00[\s\S]{5}\x48\x8b\x10\xc6\x42\x50\x01",
+    rb"\x48\x8d\x0d[\s\S]{4}\xbf\x0a\x00\x00\x00[\s\S]{5}\x48\x8b\x10\xc6\x42\x50\x01\x90[\s\S]{50,70}\x48\x8d\x0d[\s\S]{4}\xbf\x0a\x00\x00\x00[\s\S]{5}\x48\x8b\x10\xc6\x42\x50\x00",
+    b"\x00",
+    offset=0x64,
+    desc="disable bg-updater flag (x64)",
+)
+
+# amd64: updater core function sub_14273BE40 entry -> patch to immediate return (xor rax, rax; xor rbx, rbx; ret; nop)
+CLI_AUTOUPDATE_CORE_X64 = Gate(
+    rb"\x4c\x8d\xa4\x24[\s\S]{4}\x4d\x3b\x66\x10[\s\S]{6}\x55\x48\x89\xe5\x48\x81\xec\x10\x07\x00\x00[\s\S]{30,60}\xe8[\s\S]{4}\x48\x85\xc9\x0f\x84",
+    rb"\x48\x31\xc0\x48\x31\xdb\xc3\x90\x4d\x3b\x66\x10[\s\S]{6}\x55\x48\x89\xe5\x48\x81\xec\x10\x07\x00\x00[\s\S]{30,60}\xe8[\s\S]{4}\x48\x85\xc9\x0f\x84",
+    b"\x48\x31\xc0\x48\x31\xdb\xc3\x90",
+    offset=0,
+    desc="disable updater core function (x64)",
+)
+
+CLI_AUTOUPDATE_GATE = MultiGate(
+    CLI_AUTOUPDATE_BG_X64,
+    CLI_AUTOUPDATE_CORE_X64,
+    desc="disable auto-update",
+)
+
+
 
 @contextlib.contextmanager
 def _mapped(path):
@@ -152,6 +179,27 @@ def get_status(path):
 def is_already_patched(path):
     """Совместимый с IDE/asar интерфейс: True только если патч уже применён."""
     return get_status(path)[0] == "patched"
+
+
+def get_autoupdate_status(path):
+    """('patched'|'unpatched'|'unknown', None) — без исключений наружу."""
+    if not path or not os.path.isfile(path):
+        return ("unknown", None)
+    try:
+        with _mapped(path) as d:
+            try:
+                state, off, g = CLI_AUTOUPDATE_GATE.resolve(d)
+                return (state, g)
+            except LookupError:
+                return ("unknown", None)
+    except OSError:
+        return ("unknown", None)
+
+
+def is_autoupdate_disabled(path):
+    """True если фоновое авто-обновление отключено байт-патчем."""
+    return get_autoupdate_status(path)[0] == "patched"
+
 
 
 def _make_backup(path):
@@ -285,6 +333,111 @@ def do_patch_agy(path):
         panel_rows.append(("After", f"{hash_after[:8]}...{hash_after[56:]}"))
     print_panel("PATCH COMPLETE", panel_rows)
     hint("Restart Antigravity CLI for the change to take effect.")
+
+
+def do_disable_autoupdate(path):
+    from patcher.cli import confirmed
+    from patcher.utils.captcha import confirm_with_captcha
+
+    if not path or not os.path.isfile(path):
+        from patcher.cli import offer_download_and_block
+        offer_download_and_block("Antigravity CLI")
+        return
+
+    hash_before = file_hash(path)
+    info(f"Target: {color(path, COLOR_CYAN)}")
+    hint(f"Size: {color(format_bytes(file_size(path)), COLOR_CYAN)}")
+    print()
+
+    write_success = False
+    kind = off = gate = None
+    for attempt in range(2):
+        if is_locked(path):
+            if attempt == 0:
+                warn("Binary is locked (Antigravity CLI is running).")
+                if confirmed("Would you like to automatically close running agy processes and retry?"):
+                    terminate_processes(["agy"])
+                    import time
+                    time.sleep(1.5)
+                    continue
+            err("File is locked — close Antigravity CLI first.")
+            return
+
+        patches_to_apply = []
+        try:
+            with _mapped(path) as d:
+                for g in [CLI_AUTOUPDATE_BG_X64, CLI_AUTOUPDATE_CORE_X64]:
+                    try:
+                        k, o, _ = g.resolve(d)
+                        if k == "unpatched":
+                            patches_to_apply.append((o, g))
+                    except LookupError:
+                        pass
+                if not patches_to_apply:
+                    hint("Auto-update is already disabled.")
+                    if not confirm_with_captcha("Apply patch anyway?"):
+                        return
+                    # Fallback to resolving via MultiGate if forced
+                    try:
+                        k, o, g = CLI_AUTOUPDATE_GATE.resolve(d)
+                        patches_to_apply.append((o, g))
+                    except LookupError as e:
+                        err(f"{e}")
+                        handle_patch_failure()
+                        return
+        except OSError as e:
+            err(f"Read error: {e}")
+            return
+
+        _make_backup(path)
+
+        try:
+            with open(path, "r+b") as f:
+                for o, g in patches_to_apply:
+                    f.seek(o)
+                    f.write(g.fix)
+                f.flush()
+                os.fsync(f.fileno())
+            write_success = True
+            break
+        except PermissionError as e:
+            if attempt == 0:
+                warn(f"Permission denied (file locked): {e}")
+                if confirmed("Would you like to automatically close running agy processes and retry?"):
+                    terminate_processes(["agy"])
+                    import time
+                    time.sleep(1.5)
+                    continue
+            err(f"Write error (Permission denied): {e}")
+            handle_patch_failure()
+            return
+        except Exception as e:
+            err(f"Write error: {e}")
+            handle_patch_failure()
+            return
+
+    if not write_success:
+        handle_patch_failure()
+        return
+
+    hash_after = file_hash(path)
+    resign_macos_bundle(path)
+    resign_macos_binary(path)
+    if os.name == "posix":
+        _copy_to_user_bin(path)
+    desc_str = f"patched {len(patches_to_apply)} autoupdate gate(s)" if patches_to_apply else "disable auto-update"
+    step("Disable Auto-Update (bg-updater & core)", True, desc_str)
+    print()
+    panel_rows = [
+        ("Target", os.path.basename(path)),
+        ("Gates Applied", str(len(patches_to_apply))),
+    ]
+    for o, g in patches_to_apply:
+        panel_rows.append(("Gate", f"{g.desc} @ 0x{o:x}"))
+    if hash_before and hash_after:
+        panel_rows.append(("Before", f"{hash_before[:8]}...{hash_before[56:]}"))
+        panel_rows.append(("After", f"{hash_after[:8]}...{hash_after[56:]}"))
+    print_panel("DISABLE AUTO-UPDATE COMPLETE", panel_rows)
 
 
 def do_restore_agy(path):

--- a/source/patcher/cli.py
+++ b/source/patcher/cli.py
@@ -36,7 +36,14 @@ from patcher.ide.discovery import (
 )
 from patcher.ide.patcher import is_already_patched, do_patch, do_restore
 from patcher.agy.discovery import find_agy_binary, resolve_agy_path
-from patcher.agy.patcher import is_already_patched as is_agy_patched, do_patch_agy, do_restore_agy
+from patcher.agy.patcher import (
+    is_already_patched as is_agy_patched,
+    do_patch_agy,
+    do_restore_agy,
+    is_autoupdate_disabled,
+    do_disable_autoupdate,
+)
+
 
 from patcher.manager.discovery import find_manager_binary, resolve_manager_path, get_antigravity_version
 from patcher.manager.patcher import is_already_patched as is_mgr_patched, do_patch_manager, do_restore_manager
@@ -228,6 +235,9 @@ def print_target_info(main_js_path, manager_path="", agy_path="", show_search_li
         patched = is_agy_patched(agy_path)
         _kv("Patch:", "already patched" if patched else "not patched",
             COLOR_YELLOW if patched else COLOR_GREEN)
+        autoupd_off = is_autoupdate_disabled(agy_path)
+        _kv("Auto-Upd:", "disabled" if autoupd_off else "enabled",
+            COLOR_YELLOW if autoupd_off else COLOR_GREEN)
         size = file_size(agy_path)
         _kv("Size:", format_bytes(size), COLOR_GREEN if size > 0 else COLOR_YELLOW)
     else:
@@ -338,16 +348,17 @@ def run_cli():
         print_menu_row("1", "Antigravity IDE patch", "bypass region lock (isGoogleInternal)", COLOR_GREEN)
         print_menu_row("2", "Antigravity 2.0 patch", "patch language_server binary", COLOR_GREEN)
         print_menu_row("3", "Antigravity CLI (agy) patch", "unlock agy tool", COLOR_GREEN)
+        print_menu_row("4", "Disable Auto-Update (agy)", "disable bg-updater auto update", COLOR_GREEN)
 
         print_menu_section("RESTORE")
-        print_menu_row("4", "Antigravity IDE", "from backup", COLOR_YELLOW)
-        print_menu_row("5", "Antigravity 2.0", "from backup", COLOR_YELLOW)
-        print_menu_row("6", "Antigravity CLI", "from backup", COLOR_YELLOW)
+        print_menu_row("5", "Antigravity IDE", "from backup", COLOR_YELLOW)
+        print_menu_row("6", "Antigravity 2.0", "from backup", COLOR_YELLOW)
+        print_menu_row("7", "Antigravity CLI", "from backup", COLOR_YELLOW)
 
         print_menu_section("TOOLS")
-        print_menu_row("7", "Check for updates", "check GitHub releases", COLOR_CYAN)
-        print_menu_row("8", "Open GitHub repository", "source & updates", COLOR_CYAN)
-        print_menu_row("9", "Select custom path", "override auto-detected target", COLOR_CYAN)
+        print_menu_row("8", "Check for updates", "check GitHub releases", COLOR_CYAN)
+        print_menu_row("9", "Open GitHub repository", "source & updates", COLOR_CYAN)
+        print_menu_row("10", "Select custom path", "override auto-detected target", COLOR_CYAN)
 
         print()
         print_menu_row("0", "Exit", "quit the patcher", COLOR_RED)
@@ -364,7 +375,7 @@ def run_cli():
             redraw_main_screen(main_js_path, manager_path, agy_path, show_search_line=searched)
             continue
 
-        valid_choices = {str(i) for i in range(1, 10)}
+        valid_choices = {str(i) for i in range(1, 11)}
         if choice not in valid_choices:
             err("Invalid choice")
             print()
@@ -404,23 +415,32 @@ def run_cli():
                     searched = False
                     do_patch_agy(agy_path)
         elif choice == "4":
+            if agy_path and os.path.isfile(agy_path):
+                do_disable_autoupdate(agy_path)
+            else:
+                new_p = offer_download_and_block("Antigravity CLI", target_type="agy")
+                if new_p:
+                    agy_path = new_p
+                    searched = False
+                    do_disable_autoupdate(agy_path)
+        elif choice == "5":
             if main_js_path:
                 do_restore(main_js_path, show_search_line=searched)
             else:
-                err("Antigravity IDE path is not set. Please select custom path (Option 9) first.")
-        elif choice == "5":
+                err("Antigravity IDE path is not set. Please select custom path (Option 10) first.")
+        elif choice == "6":
             if manager_path:
                 do_restore_manager(manager_path)
             else:
-                err("Antigravity 2.0 (language_server) path is not set. Please select custom path (Option 9) first.")
-        elif choice == "6":
+                err("Antigravity 2.0 (language_server) path is not set. Please select custom path (Option 10) first.")
+        elif choice == "7":
             if agy_path:
                 do_restore_agy(agy_path)
             else:
-                err("Antigravity CLI path is not set. Please select custom path (Option 9) first.")
-        elif choice == "7":
-            check_for_updates(silent=False)
+                err("Antigravity CLI path is not set. Please select custom path (Option 10) first.")
         elif choice == "8":
+            check_for_updates(silent=False)
+        elif choice == "9":
             print_target_info(main_js_path, manager_path, agy_path, show_search_line=searched)
             print()
             if confirmed("Open GitHub repository in browser?"):
@@ -429,7 +449,7 @@ def run_cli():
                 ok(f"Opening: {color(url, COLOR_CYAN)}")
             else:
                 cancel("Cancelled.")
-        elif choice == "9":
+        elif choice == "10":
             while True:
                 redraw_main_screen(main_js_path, manager_path, agy_path, show_search_line=searched)
                 print_menu_section("SELECT CUSTOM PATH")


### PR DESCRIPTION
Add byte-patching mechanism and CLI menu option (Option 4) to disable auto-updates in Antigravity CLI (agy). This patches the bg-updater background check flag and updates core function entrypoints to prevent update downloads.