### PR TITLE
Fix agy account switching patch and add Farsi docs

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -1,0 +1,104 @@
+<div dir="rtl" lang="fa">
+
+# Open AG Patcher
+
+این فایل، راهنمای فارسی کوتاه برای استفاده از <span dir="ltr">Open AG Patcher</span> است.
+
+<span dir="ltr">Open AG Patcher</span> یک پچر متن‌باز برای <span dir="ltr">Antigravity IDE</span>، <span dir="ltr">Antigravity 2.0</span> و <span dir="ltr">Antigravity CLI</span> یا همان <code dir="ltr">agy</code> است. این ابزار فایل‌های نصب‌شده روی همین سیستم را تغییر می‌دهد و قبل از تغییر، نسخه پشتیبان می‌سازد.
+
+## نکته مهم
+
+این پچ فقط محلی است؛ یعنی روی فایل‌های نصب‌شده در همین دستگاه اعمال می‌شود و وضعیت حساب <span dir="ltr">Google</span>، لایسنس، یا پاسخ‌های سمت سرور را تغییر نمی‌دهد.
+
+اگر برنامه آپدیت شود، دوباره نصب شود، یا فایل باینری جایگزین شود، ممکن است لازم باشد پچ را دوباره اجرا کنید. اگر خطاهای سمت سرور مثل لایسنس نامعتبر یا محدودیت حساب دریافت می‌کنید، این پچر الزاماً نمی‌تواند آن را رفع کند.
+
+## استفاده سریع
+
+1. <span dir="ltr">Antigravity IDE</span>، <span dir="ltr">Antigravity 2.0</span> و <code dir="ltr">agy</code> را کامل ببندید.
+2. ترمینال را با دسترسی <span dir="ltr">Administrator</span> باز کنید.
+3. وارد پوشه <code dir="ltr">source</code> شوید.
+4. وابستگی‌ها را نصب کنید.
+5. اسکریپت را اجرا کنید.
+
+</div>
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+<div dir="rtl" lang="fa">
+
+در منو می‌توانید یکی از گزینه‌های پچ یا بازگردانی را انتخاب کنید:
+
+| گزینه | توضیح |
+|---:|---|
+| <code dir="ltr">1</code> | پچ <span dir="ltr">Antigravity IDE</span> برای فایل <code dir="ltr">main.js</code> |
+| <code dir="ltr">2</code> | پچ <span dir="ltr">Antigravity 2.0</span> برای فایل <code dir="ltr">language_server</code> |
+| <code dir="ltr">3</code> | پچ <span dir="ltr">Antigravity CLI</span> برای فایل <code dir="ltr">agy</code> یا <code dir="ltr">agy.exe</code> |
+| <code dir="ltr">4</code> | بازگردانی پچ <span dir="ltr">Antigravity IDE</span> |
+| <code dir="ltr">5</code> | بازگردانی پچ <span dir="ltr">Antigravity 2.0</span> |
+| <code dir="ltr">6</code> | بازگردانی پچ <span dir="ltr">Antigravity CLI</span> |
+| <code dir="ltr">9</code> | انتخاب مسیر دستی |
+
+## اجرای مستقیم با مسیر
+
+اگر تشخیص خودکار مسیر را پیدا نکرد، مسیر فایل یا پوشه نصب را مستقیم بدهید.
+
+</div>
+
+```bash
+python main.py "C:\Users\<username>\AppData\Local\Programs\Antigravity IDE"
+python main.py "C:\Users\<username>\AppData\Local\Programs\Antigravity\resources\bin\language_server.exe"
+python main.py "C:\Users\<username>\AppData\Local\agy\bin\agy.exe"
+```
+
+<div dir="rtl" lang="fa">
+
+## پچ Antigravity CLI
+
+پچ <span dir="ltr">CLI</span> روی باینری <code dir="ltr">agy</code> یا <code dir="ltr">agy.exe</code> اعمال می‌شود و قبل از تغییر، فایل پشتیبان با پسوند <code dir="ltr">.agybak</code> می‌سازد.
+
+در نسخه اصلاح‌شده <span dir="ltr">x86-64</span>، پچر فقط گیتی را تغییر می‌دهد که خطای <code dir="ltr">Eligibility check failed</code> را می‌سازد. یک بررسی مشابه در مسیر جزئیات خطا و سناریوی <span dir="ltr">logout/login</span> وجود دارد؛ آن بخش عمداً دست‌نخورده می‌ماند تا تعویض حساب و ورود دوباره خراب نشود.
+
+اگر بعد از پچ کردن همچنان خطای حساب، لایسنس، یا محدودیت سمت سرور می‌بینید، احتمالاً مشکل از وضعیت حساب یا پاسخ سرور است، نه از فایل محلی.
+
+## بازگردانی
+
+برای بازگردانی از منو استفاده کنید:
+
+</div>
+
+```text
+RESTORE -> 4, 5, or 6
+```
+
+<div dir="rtl" lang="fa">
+
+برای <span dir="ltr">CLI</span>، فایل اصلی از نسخه پشتیبان <code dir="ltr">.agybak</code> برگردانده می‌شود.
+
+## ساخت فایل اجرایی
+
+در ویندوز:
+
+</div>
+
+```bash
+cd source
+pip install -r requirements.txt
+pyinstaller --onefile --uac-admin --icon=icon.ico --name="Open_AG_Patcher_Windows" --noupx --clean --version-file=version.txt main.py
+```
+
+<div dir="rtl" lang="fa">
+
+## عیب‌یابی کوتاه
+
+اگر فایل قفل است، برنامه‌های <span dir="ltr">Antigravity</span> و پردازش <code dir="ltr">agy.exe</code> را ببندید و دوباره امتحان کنید.
+
+اگر پچر مسیر نصب را پیدا نکرد، گزینه <code dir="ltr">9</code> را بزنید و مسیر را دستی وارد کنید.
+
+اگر بعد از آپدیت برنامه پچ از بین رفت، دوباره پچر را اجرا کنید.
+
+اگر خطای <code dir="ltr">Verification Required</code> هنگام تعویض حساب دیدید، مطمئن شوید از نسخه اصلاح‌شده پچر استفاده می‌کنید؛ نسخه اصلاح‌شده نباید مسیر <span dir="ltr">logout/login</span> را پچ کند.
+
+</div>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 </div>
 
 # 🔑 Open AG Patcher
+
+**Languages:** [فارسی](README.fa.md)
+
 <p align="center">
   <a href="https://github.com/AvenCores/open-antigravity-patcher"><img src="https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54" alt="Python"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-GPL--3.0-blue?style=for-the-badge" alt="GPL-3.0 License"></a>
@@ -290,7 +293,7 @@ Antigravity CLI — отдельный Go-бинарь (`agy.exe` на Windows, 
 
 **Безопасность патча:**
 - Если байтовая сигнатура не найдена в бинаре (неизвестная/неподдерживаемая версия), патчер **отказывается патчить** и ничего не меняет — выводится «signature not found (unsupported version?)».
-- Если сигнатура встречается несколько раз (Go может компилировать одну функцию в нескольких экземплярах), патчер применяет фикс ко **всем** вхождениям — они идентичны на уровне машинного кода.
+- Для x86-64 патчер изменяет только вызывающий гейт, который формирует `Eligibility check failed`. Похожая проверка в функции детализации ошибок намеренно не патчится, чтобы не ломать сценарий logout/login и переключение аккаунта.
 - Откат выполняется через **RESTORE → `6`** (Antigravity CLI) восстановлением из `.agybak`.
 
 > **Примечание по платформам:** сигнатуры для x86-64 проверены под Windows и Intel macOS, для ARM64 — под Apple Silicon macOS. Discovery ищет бинарь кроссплатформенно (`PATH`, scoop на Windows, `/usr/local/bin`, `/opt/antigravity/bin`, `~/.local/bin` на POSIX). На Linux бинарь `agy` может быть скомпилирован иначе, и сигнатура может не совпасть — в этом случае патч честно сообщит об этом без модификации файла.

--- a/source/patcher/agy/patcher.py
+++ b/source/patcher/agy/patcher.py
@@ -86,12 +86,13 @@ class MultiGate:
 # Gate 1: CLI eligibility screen (единственный гейт начальной проверки).
 # x64:
 #   test rax,rax ; je eligible ; cmp byte[rax+8],0 ; jne eligible ; call failure_builder
-# Repeating the non-null test keeps ZF=0, so jne always selects eligible.
-# Сигнатура ограничена 16-байтным ядром проверки: хвост (call + register spills)
-# варьируется между сборками, поэтому в паттерн не включается.
+# Повторный test non-null значения оставляет ZF=0, поэтому jne всегда ведёт
+# в ветку eligible.
+# Патчим вызывающий гейт, который формирует "Eligibility check failed", а не
+# leaf-функцию детализации ошибок для logout/login и переключения аккаунта.
 CLI_GATE_X64 = Gate(
-    rb"\x48\x85\xc0\x0f\x84....\x80\x78\x08\x00\x0f\x85....",
-    rb"\x48\x85\xc0\x0f\x84....\x48\x85\xc0\x90\x0f\x85....",
+    rb"\x48\x85\xc0\x0f\x84....\x80\x78\x08\x00\x0f\x85....\xe8....\x48\x89\x84\x24\x80\x00\x00\x00",
+    rb"\x48\x85\xc0\x0f\x84....\x48\x85\xc0\x90\x0f\x85....\xe8....\x48\x89\x84\x24\x80\x00\x00\x00",
     b"\x48\x85\xc0\x90",
     offset=9,
     desc="eligibility screen off (x64)",
@@ -99,7 +100,7 @@ CLI_GATE_X64 = Gate(
 # arm64:
 #   cbnz x1,error ; cbz x0,eligible ; ldrb w1,[x0,#8] ; tbnz w1,#0,eligible
 #   bl failure_builder
-# Loading 1 instead makes tbnz always select eligible.
+# Загрузка 1 заставляет существующий tbnz всегда выбирать ветку eligible.
 # Хвост (bl + stores) варьируется — в паттерн не включается.
 CLI_GATE_ARM64 = Gate(
     rb"...\xb5...\xb4\x01\x20\x40\x39...\x37",


### PR DESCRIPTION
## Summary
- Narrow the x64 `agy` eligibility patch to the caller that raises `Eligibility check failed`, leaving the error-detail/account-switch path untouched
- Update README guidance for the corrected x64 gate behavior
- Add a Persian/Farsi README with RTL handling and usage notes

## Verification
- Ran `python -m compileall source`
- Verified patched `agy` binary layout locally: caller gate patched, detail gate restored
- Ran `agy.exe --version` successfully
