### PR TITLE
фича(патчер): добавление AUTH_GATE для agy и атомарная замена бинарников на POSIX

### DIFF
--- a/source/patcher/agy/patcher.py
+++ b/source/patcher/agy/patcher.py
@@ -136,7 +136,10 @@ def _mapped(path):
 
 
 def is_locked(path):
-    """True, если файл занят (приложение запущено)."""
+    """True, если файл занят (приложение запущено). На POSIX замена файла через os.replace
+    возможна даже при работающем процессе, поэтому блокирующим считаем только Windows."""
+    if os.name != "nt":
+        return False
     try:
         with open(path, "r+b"):
             return False
@@ -275,12 +278,27 @@ def do_patch_agy(path):
         _make_backup(path)
 
         try:
-            with open(path, "r+b") as f:
+            if os.name == "nt":
+                with open(path, "r+b") as f:
+                    for off, g in patches:
+                        f.seek(off)
+                        f.write(g.fix)
+                    f.flush()
+                    os.fsync(f.fileno())
+            else:
+                with open(path, "rb") as f:
+                    bdata = bytearray(f.read())
                 for off, g in patches:
-                    f.seek(off)
-                    f.write(g.fix)
-                f.flush()
-                os.fsync(f.fileno())
+                    bdata[off:off+len(g.fix)] = g.fix
+                tmp_path = path + ".tmp"
+                with open(tmp_path, "wb") as f:
+                    f.write(bdata)
+                    f.flush()
+                    os.fsync(f.fileno())
+                shutil.copymode(path, tmp_path)
+                fix_posix_permissions(tmp_path)
+                os.replace(tmp_path, path)
+                fix_posix_permissions(path)
             write_success = True
             break
         except PermissionError as e:
@@ -352,7 +370,14 @@ def do_restore_agy(path):
 
     hash_before = file_hash(path)
     try:
-        shutil.copy2(bak, path)
+        if os.name == "nt":
+            shutil.copy2(bak, path)
+        else:
+            tmp_path = path + ".tmp"
+            shutil.copy2(bak, tmp_path)
+            shutil.copymode(bak, tmp_path)
+            fix_posix_permissions(tmp_path)
+            os.replace(tmp_path, path)
         fix_posix_permissions(path)
     except Exception as e:
         err(f"Restore error: {e}")

--- a/source/patcher/agy/patcher.py
+++ b/source/patcher/agy/patcher.py
@@ -26,6 +26,7 @@ from patcher.utils.file import (
 )
 from patcher.utils.update import handle_patch_failure
 from patcher.utils.admin import terminate_processes
+from patcher.utils.atomic import atomic_replace_posix, apply_patches_to_data
 
 BAK_EXT = ".agybak"
 
@@ -136,10 +137,19 @@ def _mapped(path):
 
 
 def is_locked(path):
-    """True, если файл занят (приложение запущено). На POSIX замена файла через os.replace
-    возможна даже при работающем процессе, поэтому блокирующим считаем только Windows."""
+    """
+    True, если файл занят (приложение запущено).
+
+    На POSIX замена файла через os.replace возможна даже при работающем процессе,
+    поэтому блокирующим считаем только Windows.
+
+    Примечание: на POSIX это не гарантирует, что файл не используется.
+    Если нужна проверка на занятость, требуется более сложная логика
+    (например, проверка процессов или файловые блокировки).
+    """
     if os.name != "nt":
         return False
+
     try:
         with open(path, "r+b"):
             return False
@@ -279,26 +289,24 @@ def do_patch_agy(path):
 
         try:
             if os.name == "nt":
+                # Windows: прямая запись с проверкой блокировки
                 with open(path, "r+b") as f:
-                    for off, g in patches:
-                        f.seek(off)
-                        f.write(g.fix)
-                    f.flush()
-                    os.fsync(f.fileno())
-            else:
-                with open(path, "rb") as f:
                     bdata = bytearray(f.read())
-                for off, g in patches:
-                    bdata[off:off+len(g.fix)] = g.fix
-                tmp_path = path + ".tmp"
-                with open(tmp_path, "wb") as f:
+                    bdata = apply_patches_to_data(bdata, patches)
+                    f.seek(0)
                     f.write(bdata)
                     f.flush()
                     os.fsync(f.fileno())
-                shutil.copymode(path, tmp_path)
-                fix_posix_permissions(tmp_path)
-                os.replace(tmp_path, path)
-                fix_posix_permissions(path)
+            else:
+                # POSIX: атомарная замена через временный файл
+                with open(path, "rb") as f:
+                    bdata = bytearray(f.read())
+
+                bdata = apply_patches_to_data(bdata, patches)
+
+                # Атомарная замена с безопасным временным файлом
+                atomic_replace_posix(path, bytes(bdata))
+
             write_success = True
             break
         except PermissionError as e:
@@ -373,11 +381,13 @@ def do_restore_agy(path):
         if os.name == "nt":
             shutil.copy2(bak, path)
         else:
-            tmp_path = path + ".tmp"
-            shutil.copy2(bak, tmp_path)
-            shutil.copymode(bak, tmp_path)
-            fix_posix_permissions(tmp_path)
-            os.replace(tmp_path, path)
+            # Читаем бэкап в память
+            with open(bak, "rb") as f:
+                bak_data = f.read()
+
+            # Атомарная замена с метаданными из бэкапа
+            atomic_replace_posix(path, bak_data, meta_source=bak)
+
         fix_posix_permissions(path)
     except Exception as e:
         err(f"Restore error: {e}")

--- a/source/patcher/manager/patcher.py
+++ b/source/patcher/manager/patcher.py
@@ -28,6 +28,7 @@ from patcher.utils.file import (
 )
 from patcher.utils.update import handle_patch_failure
 from patcher.utils.admin import terminate_processes
+from patcher.utils.atomic import atomic_replace_posix, apply_patches_to_data
 
 BAK_EXT = ".agybak"
 
@@ -145,8 +146,19 @@ def _mapped(path):
 
 
 def is_locked(path):
+    """
+    True, если файл занят (приложение запущено).
+
+    На POSIX замена файла через os.replace возможна даже при работающем процессе,
+    поэтому блокирующим считаем только Windows.
+
+    Примечание: на POSIX это не гарантирует, что файл не используется.
+    Если нужна проверка на занятость, требуется более сложная логика
+    (например, проверка процессов или файловые блокировки).
+    """
     if os.name != "nt":
         return False
+
     try:
         with open(path, "r+b"):
             return False
@@ -253,24 +265,28 @@ def do_patch_manager(path):
 
         try:
             if os.name == "nt":
+                # Windows: прямая запись с проверкой блокировки
                 with open(path, "r+b") as f:
-                    f.seek(off)
-                    f.write(matched_gate.fix)
-                    f.flush()
-                    os.fsync(f.fileno())
-            else:
-                with open(path, "rb") as f:
                     bdata = bytearray(f.read())
-                bdata[off:off+len(matched_gate.fix)] = matched_gate.fix
-                tmp_path = path + ".tmp"
-                with open(tmp_path, "wb") as f:
+
+                    # Валидация (offset, границы, размер) и применение патча
+                    bdata = apply_patches_to_data(bdata, [(off, matched_gate)])
+
+                    f.seek(0)
                     f.write(bdata)
                     f.flush()
                     os.fsync(f.fileno())
-                shutil.copymode(path, tmp_path)
-                fix_posix_permissions(tmp_path)
-                os.replace(tmp_path, path)
-                fix_posix_permissions(path)
+            else:
+                # POSIX: атомарная замена через временный файл
+                with open(path, "rb") as f:
+                    bdata = bytearray(f.read())
+
+                # Валидация (offset, границы, размер) и применение патча
+                bdata = apply_patches_to_data(bdata, [(off, matched_gate)])
+
+                # Атомарная замена с безопасным временным файлом
+                atomic_replace_posix(path, bytes(bdata))
+
             write_success = True
             break
         except PermissionError as e:
@@ -342,11 +358,13 @@ def do_restore_manager(path):
         if os.name == "nt":
             shutil.copy2(bak, path)
         else:
-            tmp_path = path + ".tmp"
-            shutil.copy2(bak, tmp_path)
-            shutil.copymode(bak, tmp_path)
-            fix_posix_permissions(tmp_path)
-            os.replace(tmp_path, path)
+            # Читаем бэкап в память
+            with open(bak, "rb") as f:
+                bak_data = f.read()
+
+            # Атомарная замена с метаданными из бэкапа
+            atomic_replace_posix(path, bak_data, meta_source=bak)
+
         fix_posix_permissions(path)
     except Exception as e:
         err(f"Restore error: {e}")

--- a/source/patcher/manager/patcher.py
+++ b/source/patcher/manager/patcher.py
@@ -145,6 +145,8 @@ def _mapped(path):
 
 
 def is_locked(path):
+    if os.name != "nt":
+        return False
     try:
         with open(path, "r+b"):
             return False
@@ -250,11 +252,25 @@ def do_patch_manager(path):
         _make_backup(path)
 
         try:
-            with open(path, "r+b") as f:
-                f.seek(off)
-                f.write(matched_gate.fix)
-                f.flush()
-                os.fsync(f.fileno())
+            if os.name == "nt":
+                with open(path, "r+b") as f:
+                    f.seek(off)
+                    f.write(matched_gate.fix)
+                    f.flush()
+                    os.fsync(f.fileno())
+            else:
+                with open(path, "rb") as f:
+                    bdata = bytearray(f.read())
+                bdata[off:off+len(matched_gate.fix)] = matched_gate.fix
+                tmp_path = path + ".tmp"
+                with open(tmp_path, "wb") as f:
+                    f.write(bdata)
+                    f.flush()
+                    os.fsync(f.fileno())
+                shutil.copymode(path, tmp_path)
+                fix_posix_permissions(tmp_path)
+                os.replace(tmp_path, path)
+                fix_posix_permissions(path)
             write_success = True
             break
         except PermissionError as e:
@@ -323,7 +339,14 @@ def do_restore_manager(path):
 
     hash_before = file_hash(path)
     try:
-        shutil.copy2(bak, path)
+        if os.name == "nt":
+            shutil.copy2(bak, path)
+        else:
+            tmp_path = path + ".tmp"
+            shutil.copy2(bak, tmp_path)
+            shutil.copymode(bak, tmp_path)
+            fix_posix_permissions(tmp_path)
+            os.replace(tmp_path, path)
         fix_posix_permissions(path)
     except Exception as e:
         err(f"Restore error: {e}")

--- a/source/patcher/utils/atomic.py
+++ b/source/patcher/utils/atomic.py
@@ -1,0 +1,156 @@
+import os
+import stat
+import tempfile
+
+
+def fsync_dir(dirpath):
+    """Синхронизировать директорию для надёжности переименования."""
+    if os.name == "nt":
+        return
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+
+    fd = os.open(dirpath, flags)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def atomic_replace_posix(path, data, meta_source=None):
+    """
+    Атомарная замена файла на POSIX-системах с безопасным временным файлом.
+
+    Args:
+        path: Целевой путь файла
+        data: Байтовые данные для записи
+        meta_source: Файл-источник для метаданных (владелец, права).
+                     По умолчанию используется path.
+    """
+    path = os.path.abspath(path)
+
+    # Запрещаем работу с символическими ссылками
+    if os.path.islink(path):
+        raise ValueError("Refusing to patch symlink")
+
+    if not os.path.isfile(path):
+        raise ValueError("Target is not a regular file")
+
+    if meta_source is None:
+        meta_source = path
+
+    st = os.stat(meta_source)
+    directory = os.path.dirname(path)
+
+    # Безопасное создание временного файла с O_EXCL
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(path)}.",
+        suffix=".tmp",
+        dir=directory,
+    )
+
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+
+            # Сохраняем владельца ДО chmod (chown может сбросить setuid/setgid)
+            try:
+                os.fchown(f.fileno(), st.st_uid, st.st_gid)
+            except OSError:
+                # Может не хватить прав, это не всегда критично
+                pass
+
+            # Применяем права из оригинального файла
+            os.fchmod(f.fileno(), stat.S_IMODE(st.st_mode))
+
+        # Атомарная замена
+        os.replace(tmp_path, path)
+
+        # Синхронизируем директорию
+        fsync_dir(directory)
+
+        tmp_path = None  # Помечаем как успешно заменённый
+    finally:
+        # Удаляем временный файл при ошибке
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def validate_patch_params(bdata, patches):
+    """
+    Валидация параметров патчей перед применением.
+
+    Args:
+        bdata: bytearray с данными файла
+        patches: список патчей в формате (offset, gate_object)
+
+    Raises:
+        ValueError: если параметры патча некорректны
+    """
+    for off, g in patches:
+        # Проверка на отрицательное смещение
+        if off < 0:
+            raise ValueError(f"Negative offset: {off}")
+
+        fix = g.fix
+
+        # Если есть оригинальные байты для проверки
+        if hasattr(g, "orig"):
+            orig = g.orig
+
+            # Патч не должен менять размер файла
+            if len(fix) != len(orig):
+                raise ValueError(
+                    f"Patch changes file size: orig={len(orig)}, fix={len(fix)}"
+                )
+
+            # Проверка выхода за границы файла
+            if off + len(orig) > len(bdata):
+                raise ValueError(
+                    f"Patch offset out of bounds: offset={off}, "
+                    f"patch_size={len(orig)}, file_size={len(bdata)}"
+                )
+
+            # Проверка соответствия оригинальных байтов
+            if bdata[off:off + len(orig)] != orig:
+                raise ValueError(
+                    f"Original bytes mismatch at offset {off}"
+                )
+        else:
+            # Без оригинала хотя бы проверяем границы
+            if off + len(fix) > len(bdata):
+                raise ValueError(
+                    f"Patch offset out of bounds: offset={off}, "
+                    f"patch_size={len(fix)}, file_size={len(bdata)}"
+                )
+
+
+def apply_patches_to_data(bdata, patches):
+    """
+    Применение патчей к bytearray с валидацией.
+
+    Args:
+        bdata: bytearray с данными файла
+        patches: список патчей в формате (offset, gate_object)
+
+    Returns:
+        bytearray: модифицированные данные
+    """
+    # Валидация всех патчей перед применением
+    validate_patch_params(bdata, patches)
+
+    # Применяем патчи
+    for off, g in patches:
+        if hasattr(g, "orig"):
+            bdata[off:off + len(g.orig)] = g.fix
+        else:
+            bdata[off:off + len(g.fix)] = g.fix
+
+    return bdata


### PR DESCRIPTION
 ### Что сделано:
    1. **AUTH_GATE для AGY:** Добавлен гейт `AUTH_GATE` (`hasValidAuth=true`) для
  бинарника `agy` под архитектуры x64 и arm64.
    2. **Атомарная замена на POSIX:**
       - Реализована запись через временный `.tmp` файл и `os.replace` для `agy` и
  `manager` (`language_server`), что предотвращает ошибки блокировки при работающих
  процессах.
       - Добавлено сохранение прав исполняемого файла (`shutil.copymode(path,
  tmp_path)`), чтобы бинарники не теряли флаг `+x` при замене.
       - `is_locked` на POSIX теперь возвращает `False`, так как замена через `os.
  replace` поддерживается ядром ОС.

